### PR TITLE
UPDATE: Runtime parameters show in log filename

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+numberOfRuns=10000000
+neighbourPeakScalingFactor=2.0
+acceptanceProbabilityScalingFactor=1.0
+temperatureScalingFactor=100.0
+temperatureDivisor=20000
+
+# used for dynamic filename including the command-line arguments
+logSuffix="${numberOfRuns}-${neighbourPeakScalingFactor}-${acceptanceProbabilityScalingFactor}-${temperatureScalingFactor}-${temperatureDivisor}"
+
 mvn clean package
 
-java -jar target/SchwarzschildSimulatedAnnealing-1.0-SNAPSHOT-shaded.jar numberOfRuns 10000000 neighbourPeakScalingFactor 2.0 acceptanceProbabilityScalingFactor 1.0 temperatureScalingFactor 100.0 temperatureDivisor 20000
+java -DlogSuffix="$logSuffix" -jar target/SchwarzschildSimulatedAnnealing-1.0-SNAPSHOT-shaded.jar \
+    numberOfRuns "$numberOfRuns" \
+    neighbourPeakScalingFactor "$neighbourPeakScalingFactor" \
+    acceptanceProbabilityScalingFactor "$acceptanceProbabilityScalingFactor" \
+    temperatureScalingFactor "$temperatureScalingFactor" \
+    temperatureDivisor "$temperatureDivisor"

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -4,8 +4,8 @@
   <Appenders>
     <RollingFile
      name="File"
-     fileName="logs/SchwarzschildSimulatedAnnealing.log"
-     filePattern="logs/SchwarzschildSimulatedAnnealing-%i.log"
+     fileName="logs/SchwarzschildSimulatedAnnealing-${sys:logSuffix:-default}.log"
+     filePattern="logs/SchwarzschildSimulatedAnnealing-${sys:logSuffix:-default}-%i.log"
     >
       <PatternLayout pattern="%d{EEE dd MMM yyyy 'at' HH:mm:ss.SSS z} %level %c [%t] %m%n"
       />


### PR DESCRIPTION
When you run the program from run.sh (or pass in the arguments via java -D) the log filename will contain those parameters, to easily see which log was from which run.